### PR TITLE
Changed cleanup directory when CreateSubdirectories is true

### DIFF
--- a/Frends.Files.LocalBackup/CHANGELOG.md
+++ b/Frends.Files.LocalBackup/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.0.3] - 2022-11-25
+### Fixed
+- Fixed issue when using CreateSubdirectories Cleanup uses same directory which is created in Backup and when there's no files to backup the directory is deleted and cleanup won't find the directory.
+
 ## [2.0.2] - 2022-10-13
 ### Changed
 - Cleanup will clean individual files in addition to directories when CreateSubdirectories is false.

--- a/Frends.Files.LocalBackup/Frends.Files.LocalBackup.Tests/Frends.Files.LocalBackup.Tests.csproj
+++ b/Frends.Files.LocalBackup/Frends.Files.LocalBackup.Tests/Frends.Files.LocalBackup.Tests.csproj
@@ -8,9 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+	<PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+	<PackageReference Include="nunit" Version="3.12.0" />
+	<PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
     <PackageReference Include="coverlet.collector" Version="3.1.0" />
   </ItemGroup>
 

--- a/Frends.Files.LocalBackup/Frends.Files.LocalBackup.Tests/UnitTests.cs
+++ b/Frends.Files.LocalBackup/Frends.Files.LocalBackup.Tests/UnitTests.cs
@@ -365,8 +365,8 @@ public class UnitTests
             TaskExecutionId = Guid.NewGuid().ToString()
         };
 
-        var result = Files.LocalBackup(input, new CancellationToken());
-        Assert.AreEqual(result.Cleanups.Count, 0);
+        var result = Files.LocalBackup(input, default);
+        Assert.AreEqual(0, result.Cleanups.Count);
     }
 
     public void CreateTestFiles()

--- a/Frends.Files.LocalBackup/Frends.Files.LocalBackup/Frends.Files.LocalBackup.csproj
+++ b/Frends.Files.LocalBackup/Frends.Files.LocalBackup/Frends.Files.LocalBackup.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
 	<TargetFrameworks>net6.0;netstandard2.0;net471</TargetFrameworks>
 	<LangVersion>Latest</LangVersion>
-	<Version>2.0.2</Version>
+	<Version>2.0.3</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.Files.LocalBackup/Frends.Files.LocalBackup/LocalBackup.cs
+++ b/Frends.Files.LocalBackup/Frends.Files.LocalBackup/LocalBackup.cs
@@ -36,7 +36,7 @@ namespace Frends.Files.LocalBackup
 
             var (directory, backup) = CreateBackup(input, backupDirectory,  cancellationToken);
 
-            var cleanup = input.Cleanup ? CleanUp(input, backupDirectory, cancellationToken) : null;
+            var cleanup = input.Cleanup ? CleanUp(input, input.BackupDirectory, cancellationToken) : null;
 
             return new Result(directory, backup, cleanup);
         }
@@ -121,7 +121,7 @@ namespace Frends.Files.LocalBackup
                     return timeStamp < DateTime.UtcNow.AddDays(-input.DaysOlder);
                 }
             }
-            return new FileInfo(dirPath).LastWriteTime < DateTime.UtcNow.AddDays(-input.DaysOlder);
+            return File.GetCreationTimeUtc(dirPath) < DateTime.UtcNow.AddDays(-input.DaysOlder);
         }
 
         private static bool FileMatchesMask(string filename, string mask)


### PR DESCRIPTION
#12 
- Fixed issue when using CreateSubdirectories Cleanup uses same directory which is created in Backup and when there's no files to backup the directory is deleted and cleanup won't find the directory.