### PR TITLE
Files.WriteBytes - Memory leak fix

### DIFF
--- a/Frends.Files.WriteBytes/CHANGELOG.md
+++ b/Frends.Files.WriteBytes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.1] - 2023-08-10
+### Fixed
+- Fixed memory leak from ExecuteWriteBytes by adding using statement when opening a new MewmoryStream.
+
 ## [1.0.0] - 2023-04-17
 ### Added
 - Initial implementation

--- a/Frends.Files.WriteBytes/Frends.Files.WriteBytes/Frends.Files.WriteBytes.csproj
+++ b/Frends.Files.WriteBytes/Frends.Files.WriteBytes/Frends.Files.WriteBytes.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
 	<TargetFramework>net6.0</TargetFramework>
 	<LangVersion>Latest</LangVersion>
-	<Version>1.0.0</Version>
+	<Version>1.0.1</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.Files.WriteBytes/Frends.Files.WriteBytes/WriteBytes.cs
+++ b/Frends.Files.WriteBytes/Frends.Files.WriteBytes/WriteBytes.cs
@@ -46,19 +46,15 @@ public class Files
 
     private static async Task<Result> ExecuteWriteBytes(Input input, Options options)
     {
-        var bytes = input?.ContentBytes as byte[];
+        byte[] bytes = input?.ContentBytes as byte[];
         if (bytes == null)
-        {
             throw new ArgumentException("Input.ContentBytes must be a byte array", nameof(input.ContentBytes));
-        }
 
         var fileMode = GetAndCheckWriteMode(options.WriteBehaviour, input.Path);
 
-        using (var fileStream = new FileStream(input.Path, fileMode, FileAccess.Write, FileShare.Write, 4096, useAsync: true))
-        {
-            var memoryStream = new MemoryStream(bytes);
-            await memoryStream.CopyToAsync(fileStream).ConfigureAwait(false);
-        }
+        using var fileStream = new FileStream(input.Path, fileMode, FileAccess.Write, FileShare.Write, 4096, useAsync: true);
+        using var memoryStream = new MemoryStream(bytes);
+        await memoryStream.CopyToAsync(fileStream).ConfigureAwait(false);
 
         return new Result(new FileInfo(input.Path));
     }
@@ -83,9 +79,7 @@ public class Files
 
             case WriteBehaviour.Throw:
                 if (File.Exists(filePath))
-                {
                     throw new IOException($"File already exists: {filePath}.");
-                }
                 return FileMode.Create;
             default:
                 throw new ArgumentException("Unsupported write option: " + givenWriteBehaviour);


### PR DESCRIPTION
#46 
- Fixed memory leak from ExecuteWriteBytes by adding using statement when opening a new MewmoryStream.