### PR TITLE
Fixed bug in CreateBackup

### DIFF
--- a/Frends.Files.LocalBackup/CHANGELOG.md
+++ b/Frends.Files.LocalBackup/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+##[2.1.2] - 2023-08-31
+### Fixed
+- Fixed bug in CreateBackup which was caused by Task not been able to delete the directory if there are directories present.
+
 ## [2.1.1] - 2023-08-08
 ### Fixed
 - Added check for implicit match for the file and filemask.

--- a/Frends.Files.LocalBackup/Frends.Files.LocalBackup.Tests/UnitTests.cs
+++ b/Frends.Files.LocalBackup/Frends.Files.LocalBackup.Tests/UnitTests.cs
@@ -447,6 +447,29 @@ public class UnitTests
     }
 
     [TestMethod]
+    public void TestBackup_NoFilesForBackupShouldNotDeleteExistingDirectory()
+    {
+        var backup = Path.Combine(_dir, "Backup");
+
+        Directory.CreateDirectory(Path.Combine(backup, Guid.NewGuid().ToString()));
+
+        var input = new Input
+        {
+            SourceDirectory = _dir,
+            SourceFile = "*.8CO",
+            BackupDirectory = backup,
+            CreateSubdirectories = false,
+            Cleanup = false,
+            TaskExecutionId = Guid.NewGuid().ToString()
+        };
+
+        var result = Files.LocalBackup(input, default);
+        Assert.AreEqual(0, result.FileCountInBackup);
+
+        Directory.Delete(backup, true);
+    }
+
+    [TestMethod]
     public void TestBackup_FileIncludesSpecialCharacters()
     {
         var buDir = Path.Combine(_dir, "Backup");
@@ -556,7 +579,6 @@ public class UnitTests
             Path.Combine(_dir, "Test2.txt"),
             Path.Combine(_dir, "Test1.xml"),
             Path.Combine(_dir, "p}ro(_tes[t.txt"),
-            Path.Combine(_dir, "Test1.xml"),
             Path.Combine(_dir, "Sub", "Overwrite.txt"),
             Path.Combine(_dir, "Pro", "pro_test.txt"),
             Path.Combine(_dir, "Pro", "pref_test.txt"),

--- a/Frends.Files.LocalBackup/Frends.Files.LocalBackup/Frends.Files.LocalBackup.csproj
+++ b/Frends.Files.LocalBackup/Frends.Files.LocalBackup/Frends.Files.LocalBackup.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
 	<TargetFrameworks>net6.0;netstandard2.0;net471</TargetFrameworks>
 	<LangVersion>Latest</LangVersion>
-	<Version>2.1.1</Version>
+	<Version>2.1.2</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.Files.LocalBackup/Frends.Files.LocalBackup/LocalBackup.cs
+++ b/Frends.Files.LocalBackup/Frends.Files.LocalBackup/LocalBackup.cs
@@ -78,7 +78,7 @@ namespace Frends.Files.LocalBackup
                 }
             }
 
-            if (!Directory.GetFiles(backupDirectory).Any())
+            if (!Directory.GetFiles(backupDirectory).Any() && !Directory.GetDirectories(backupDirectory).Any())
             {
                 Directory.Delete(backupDirectory, false);
                 return new Tuple<string, List<string>>("No source files present to backup.", new List<string>());


### PR DESCRIPTION
#51 
- Fixed bug in CreateBackup which was caused by Task not been able to delete the directory if there are directories present.