### PR TITLE
Files.Copy - Fixed bug with file access

### DIFF
--- a/Frends.Files.Copy/CHANGELOG.md
+++ b/Frends.Files.Copy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# [1.0.1] - 2023-09-21
+### Fixed
+- Fixed bug with file access. Changed File.Open to use FileAccess.Read, because there's no reason to give more access to the Task.
+
 ## [1.0.0] - 2023-02-14
 ### Added
 - Initial implementation

--- a/Frends.Files.Copy/Frends.Files.Copy/Copy.cs
+++ b/Frends.Files.Copy/Frends.Files.Copy/Copy.cs
@@ -23,7 +23,10 @@ public class Files
     /// Copy files.
     /// [Documentation](https://tasks.frends.com/tasks/frends-tasks/Frends.Files.Copy)
     /// </summary>
-    /// <returns>List [ Object { string SourcePath, string Path } ]</returns>
+    /// <param name="input">Input parameters for the Task.</param>
+    /// <param name="options">Additional options for the Task.</param>
+    /// <param name="cancellationToken">CancellationToken given by Frends.</param>
+    /// <returns>List [ Object { string SourcePath, string TargetPath } ]</returns>
     public static async Task<Result> Copy([PropertyTab] Input input, [PropertyTab] Options options, CancellationToken cancellationToken)
     {
         var result = await ExecuteActionAsync(() => ExecuteCopyAsync(input, options, cancellationToken),

--- a/Frends.Files.Copy/Frends.Files.Copy/Copy.cs
+++ b/Frends.Files.Copy/Frends.Files.Copy/Copy.cs
@@ -99,7 +99,7 @@ public class Files
 
     private static async Task CopyFileAsync(string source, string destination, CancellationToken cancellationToken)
     {
-        using FileStream sourceStream = File.Open(source, FileMode.Open);
+        using FileStream sourceStream = File.Open(source, FileMode.Open, FileAccess.Read);
         using FileStream destinationStream = File.Open(destination, FileMode.CreateNew);
 
         await sourceStream.CopyToAsync(destinationStream, 81920, cancellationToken).ConfigureAwait(false);

--- a/Frends.Files.Copy/Frends.Files.Copy/Frends.Files.Copy.csproj
+++ b/Frends.Files.Copy/Frends.Files.Copy/Frends.Files.Copy.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
 	<TargetFramework>net6.0</TargetFramework>
 	<LangVersion>Latest</LangVersion>
-	<Version>1.0.0</Version>
+	<Version>1.0.1</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>


### PR DESCRIPTION
#53 
- Fixed bug with file access. Changed File.Open to use FileAccess.Read, because there's no reason to give more access to the Task.
