### PR TITLE
LocalBackupFixed - issue with FilePaths

### DIFF
--- a/Frends.Files.LocalBackup/CHANGELOG.md
+++ b/Frends.Files.LocalBackup/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [2.1.3] - 2024-01-15
+## [2.1.3] - 2024-01-16
 ### Fixed
 - Fixed how FilePaths were handled. Changed casting to string[] to convert the object into a string[] by casting it first as a object[].
 

--- a/Frends.Files.LocalBackup/CHANGELOG.md
+++ b/Frends.Files.LocalBackup/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.1.3] - 2024-01-15
+### Fixed
+- Fixed how FilePaths were handled. Changed casting to string[] to convert the object into a string[] by casting it first as a object[].
+
 ## [2.1.2] - 2023-08-31
 ### Fixed
 - Fixed bug in CreateBackup which was caused by Task not been able to delete the directory if there are directories present.

--- a/Frends.Files.LocalBackup/Frends.Files.LocalBackup.Tests/UnitTests.cs
+++ b/Frends.Files.LocalBackup/Frends.Files.LocalBackup.Tests/UnitTests.cs
@@ -11,7 +11,7 @@ namespace Frends.Files.LocalBackup.Tests;
 public class UnitTests
 {
     private readonly string _dir = Path.Combine(Environment.CurrentDirectory, "Tests"); // ...Test\bin\Debug\net6.0\
-    Input? input;
+    Input? paramInput;
 
     [TestInitialize]
     public void Setup()
@@ -33,7 +33,7 @@ public class UnitTests
     {
         var buDir = Path.Combine(_dir, "Backup");
 
-        input = new Input()
+        paramInput = new Input()
         {
             SourceDirectory = _dir,
             SourceFile = "*",
@@ -44,7 +44,7 @@ public class UnitTests
             CreateSubdirectories = false
         };
 
-        var result = Files.LocalBackup(input, default);
+        var result = Files.LocalBackup(paramInput, default);
         Assert.IsNotNull(result);
 
         foreach (var dir in Directory.GetDirectories(buDir))
@@ -65,7 +65,7 @@ public class UnitTests
     {
         var buDir = Path.Combine(_dir, "Backup");
 
-        input = new Input()
+        paramInput = new Input()
         {
             SourceDirectory = _dir,
             SourceFile = "*",
@@ -76,7 +76,7 @@ public class UnitTests
             CreateSubdirectories = true
         };
 
-        var result = Files.LocalBackup(input, default);
+        var result = Files.LocalBackup(paramInput, default);
         Assert.IsNotNull(result);
 
         foreach (var dir in Directory.GetDirectories(buDir, "2022-05-*"))
@@ -97,7 +97,7 @@ public class UnitTests
     {
         var buDir = Path.Combine(_dir, "Backup");
 
-        input = new Input()
+        paramInput = new Input()
         {
             SourceDirectory = _dir,
             SourceFile = "*",
@@ -108,7 +108,7 @@ public class UnitTests
             CreateSubdirectories = true
         };
 
-        var result = Files.LocalBackup(input, default);
+        var result = Files.LocalBackup(paramInput, default);
         Assert.IsNotNull(result);
 
         foreach (var dir in Directory.GetDirectories(buDir, "*qwerty123*"))
@@ -129,7 +129,7 @@ public class UnitTests
     {
         var buDir = Path.Combine(_dir, "Backup");
 
-        input = new Input()
+        paramInput = new Input()
         {
             SourceDirectory = _dir,
             SourceFile = "Test*",
@@ -139,7 +139,7 @@ public class UnitTests
             Cleanup = false,
         };
 
-        var result = Files.LocalBackup(input, default);
+        var result = Files.LocalBackup(paramInput, default);
         Assert.IsNotNull(result);
 
         foreach (var dir in Directory.GetDirectories(buDir, "2022-05-*"))
@@ -161,7 +161,7 @@ public class UnitTests
     {
         var buDir = Path.Combine(_dir, "Backup");
 
-        input = new Input()
+        paramInput = new Input()
         {
             SourceDirectory = _dir,
             SourceFile = "Test1.(txt|xml)",
@@ -171,7 +171,7 @@ public class UnitTests
             Cleanup = false,
         };
 
-        var result = Files.LocalBackup(input, default);
+        var result = Files.LocalBackup(paramInput, default);
         Assert.IsNotNull(result);
 
         foreach (var dir in Directory.GetDirectories(buDir, "2022-05-*"))
@@ -193,7 +193,7 @@ public class UnitTests
     {
         var buDir = Path.Combine(_dir, "Backup");
 
-        input = new Input()
+        paramInput = new Input()
         {
             SourceDirectory = _dir,
             SourceFile = "Test1.[^t][^x][^t]",
@@ -203,7 +203,7 @@ public class UnitTests
             Cleanup = false,
         };
 
-        var result = Files.LocalBackup(input, default);
+        var result = Files.LocalBackup(paramInput, default);
         Assert.IsNotNull(result);
 
         foreach (var dir in Directory.GetDirectories(buDir, "2022-05-*"))
@@ -225,7 +225,7 @@ public class UnitTests
     {
         var buDir = Path.Combine(_dir, "Backup", "Pro");
 
-        input = new Input()
+        paramInput = new Input()
         {
             SourceDirectory = Path.Combine(_dir, "Pro"),
             SourceFile = "<regex>^(?!prof).*_test.txt",
@@ -235,7 +235,7 @@ public class UnitTests
             Cleanup = false,
         };
 
-        var result = Files.LocalBackup(input, default);
+        var result = Files.LocalBackup(paramInput, default);
         Assert.IsNotNull(result);
 
         foreach (var dir in Directory.GetDirectories(buDir, "2022-05-*"))
@@ -259,7 +259,7 @@ public class UnitTests
         var backupDirectory = Path.Combine(_dir, "Cleanup", $"{timestampString}-{Guid.NewGuid()}");
         Directory.CreateDirectory(backupDirectory);
 
-        input = new Input()
+        paramInput = new Input()
         {
             SourceDirectory = _dir,
             SourceFile = "*",
@@ -270,7 +270,7 @@ public class UnitTests
             CreateSubdirectories = true,
         };
 
-        var result = Files.LocalBackup(input, default);
+        var result = Files.LocalBackup(paramInput, default);
         Assert.IsNotNull(result);
     }
 
@@ -280,7 +280,7 @@ public class UnitTests
     [TestMethod]
     public void CleanupFile_CreateSubdirectoriesFalse_Test()
     {
-        input = new Input()
+        paramInput = new Input()
         {
             SourceDirectory = _dir,
             SourceFile = "*",
@@ -295,7 +295,7 @@ public class UnitTests
         Directory.CreateDirectory(backupDirectory);
         Directory.SetLastWriteTimeUtc(backupDirectory, DateTime.Now.AddDays(-2));
 
-        var result = Files.LocalBackup(input, default);
+        var result = Files.LocalBackup(paramInput, default);
         Assert.IsNotNull(result);
         Assert.IsNotNull(result.Cleanups);
         Assert.IsFalse(Directory.Exists(backupDirectory));
@@ -309,7 +309,7 @@ public class UnitTests
     {
         var backup = Path.Combine(_dir, "Cleanup");
 
-        input = new Input()
+        paramInput = new Input()
         {
             SourceDirectory = _dir,
             SourceFile = "*",
@@ -320,7 +320,7 @@ public class UnitTests
             CreateSubdirectories = false,
         };
 
-        Files.LocalBackup(input, default);
+        Files.LocalBackup(paramInput, default);
         foreach (var dir in Directory.GetDirectories(backup))
             Directory.SetLastWriteTime(dir, DateTime.Now.AddDays(-2));
         var files = Directory.GetFiles(backup).ToList();
@@ -330,7 +330,7 @@ public class UnitTests
             var newName = Path.GetFileNameWithoutExtension(file) + "(1)" + Path.GetExtension(file);
             File.Move(file, Path.Combine(Path.GetDirectoryName(file) ?? backup, newName));
         }
-        var result = Files.LocalBackup(input, default);
+        var result = Files.LocalBackup(paramInput, default);
         Assert.AreEqual(4, result.Cleanups.Count);
     }
 
@@ -339,7 +339,7 @@ public class UnitTests
     {
         var backup = Path.Combine(_dir, "Cleanup");
 
-        input = new Input()
+        paramInput = new Input()
         {
             SourceDirectory = _dir,
             SourceFile = "*",
@@ -354,14 +354,14 @@ public class UnitTests
         var newDir = Path.Combine(backup, Guid.NewGuid().ToString());
         Directory.CreateDirectory(newDir);
         Directory.SetCreationTimeUtc(newDir, DateTime.UtcNow.AddDays(-2));
-        var result = Files.LocalBackup(input, default);
+        var result = Files.LocalBackup(paramInput, default);
         Assert.AreEqual(1, result.Cleanups.Count);
     }
 
     [TestMethod]
     public void TestCleanupWithoutBackup()
     {
-        var input = new Input
+        var paramInput = new Input
         {
             SourceDirectory = Environment.CurrentDirectory,
             SourceFile = "FileThatDontExist",
@@ -373,14 +373,14 @@ public class UnitTests
             TaskExecutionId = Guid.NewGuid().ToString()
         };
 
-        var result = Files.LocalBackup(input, default);
+        var result = Files.LocalBackup(paramInput, default);
         Assert.AreEqual(0, result.Cleanups.Count);
     }
 
     [TestMethod]
     public void TestBackupWithFilePaths()
     {
-        var input = new Input
+        var paramInput = new Input
         {
             SourceDirectory = "",
             SourceFile = "",
@@ -396,14 +396,14 @@ public class UnitTests
             DaysOlder = 14,
             TaskExecutionId = Guid.NewGuid().ToString()
         };
-        var result = Files.LocalBackup(input, default);
+        var result = Files.LocalBackup(paramInput, default);
         Assert.AreEqual(3, result.FileCountInBackup);
     }
 
     [TestMethod]
     public void TestBackup_OnlyFilePathsAreUsedEvenIfDirectoryAndFileMaskIsSet()
     {
-        var input = new Input
+        var paramInput = new Input
         {
             SourceDirectory = _dir,
             SourceFile = "*",
@@ -419,14 +419,14 @@ public class UnitTests
             DaysOlder = 14,
             TaskExecutionId = Guid.NewGuid().ToString()
         };
-        var result = Files.LocalBackup(input, default);
+        var result = Files.LocalBackup(paramInput, default);
         Assert.AreEqual(3, result.FileCountInBackup);
     }
 
     [TestMethod]
     public void TestBackup_FilePathsAsObjectArray()
     {
-        var input = new Input
+        var paramInput = new Input
         {
             SourceDirectory = _dir,
             SourceFile = "*",
@@ -442,14 +442,14 @@ public class UnitTests
             DaysOlder = 14,
             TaskExecutionId = Guid.NewGuid().ToString()
         };
-        var result = Files.LocalBackup(input, default);
+        var result = Files.LocalBackup(paramInput, default);
         Assert.AreEqual(3, result.FileCountInBackup);
     }
 
     [TestMethod]
     public void TestBackup_FilePathsFilesNotFound()
     {
-        var input = new Input
+        var paramInput = new Input
         {
             SourceDirectory = "",
             SourceFile = "",
@@ -465,7 +465,7 @@ public class UnitTests
             DaysOlder = 14,
             TaskExecutionId = Guid.NewGuid().ToString()
         };
-        var result = Files.LocalBackup(input, default);
+        var result = Files.LocalBackup(paramInput, default);
         Assert.AreEqual(0, result.FileCountInBackup);
     }
 
@@ -476,7 +476,7 @@ public class UnitTests
 
         Directory.CreateDirectory(Path.Combine(backup, Guid.NewGuid().ToString()));
 
-        var input = new Input
+        var paramInput = new Input
         {
             SourceDirectory = _dir,
             SourceFile = "*.8CO",
@@ -486,7 +486,7 @@ public class UnitTests
             TaskExecutionId = Guid.NewGuid().ToString()
         };
 
-        var result = Files.LocalBackup(input, default);
+        var result = Files.LocalBackup(paramInput, default);
         Assert.AreEqual(0, result.FileCountInBackup);
 
         Directory.Delete(backup, true);
@@ -497,7 +497,7 @@ public class UnitTests
     {
         var buDir = Path.Combine(_dir, "Backup");
 
-        input = new Input()
+        paramInput = new Input()
         {
             SourceDirectory = Path.Combine(_dir, "Special"),
             SourceFile = "p}ro(_tes[t.txt",
@@ -507,9 +507,9 @@ public class UnitTests
             Cleanup = false,
         };
 
-        var result = Files.LocalBackup(input, default);
+        var result = Files.LocalBackup(paramInput, default);
         Assert.AreEqual(1, result.Backups.Count);
-        Assert.IsTrue(File.Exists(Path.Combine(buDir, input.SourceFile)));
+        Assert.IsTrue(File.Exists(Path.Combine(buDir, paramInput.SourceFile)));
     }
 
     [TestMethod]
@@ -517,7 +517,7 @@ public class UnitTests
     {
         var buDir = Path.Combine(_dir, "Backup");
 
-        input = new Input()
+        paramInput = new Input()
         {
             SourceDirectory = _dir,
             SourceFile = "p}ro(_tes[t.txt",
@@ -527,9 +527,9 @@ public class UnitTests
             Cleanup = false,
         };
 
-        var result = Files.LocalBackup(input, default);
+        var result = Files.LocalBackup(paramInput, default);
         Assert.AreEqual(1, result.Backups.Count);
-        Assert.IsTrue(File.Exists(Path.Combine(buDir, input.SourceFile)));
+        Assert.IsTrue(File.Exists(Path.Combine(buDir, paramInput.SourceFile)));
     }
 
 
@@ -538,7 +538,7 @@ public class UnitTests
     {
         var buDir = Path.Combine(_dir, "Backup");
 
-        input = new Input()
+        paramInput = new Input()
         {
             SourceDirectory = _dir,
             SourceFile = "*.txt",
@@ -548,7 +548,7 @@ public class UnitTests
             Cleanup = false,
         };
 
-        var result = Files.LocalBackup(input, default);
+        var result = Files.LocalBackup(paramInput, default);
         Assert.AreEqual(3, result.Backups.Count);
     }
 
@@ -557,7 +557,7 @@ public class UnitTests
     {
         var buDir = Path.Combine(_dir, "Backup");
 
-        input = new Input()
+        paramInput = new Input()
         {
             SourceDirectory = _dir,
             SourceFile = "p}ro(_tes[*",
@@ -567,7 +567,7 @@ public class UnitTests
             Cleanup = false,
         };
 
-        var result = Files.LocalBackup(input, default);
+        var result = Files.LocalBackup(paramInput, default);
         Assert.AreEqual(1, result.Backups.Count);
     }
 
@@ -576,7 +576,7 @@ public class UnitTests
     {
         var buDir = Path.Combine(_dir, "Backup");
 
-        input = new Input()
+        paramInput = new Input()
         {
             SourceDirectory = _dir,
             SourceFile = "*}ro(_tes[t.txt",
@@ -586,7 +586,7 @@ public class UnitTests
             Cleanup = false,
         };
 
-        var result = Files.LocalBackup(input, default);
+        var result = Files.LocalBackup(paramInput, default);
         Assert.AreEqual(1, result.Backups.Count);
     }
 

--- a/Frends.Files.LocalBackup/Frends.Files.LocalBackup.Tests/UnitTests.cs
+++ b/Frends.Files.LocalBackup/Frends.Files.LocalBackup.Tests/UnitTests.cs
@@ -424,6 +424,29 @@ public class UnitTests
     }
 
     [TestMethod]
+    public void TestBackup_FilePathsAsObjectArray()
+    {
+        var input = new Input
+        {
+            SourceDirectory = _dir,
+            SourceFile = "*",
+            FilePaths = new object[]
+            {
+                Path.Combine(_dir, "Test1.txt"),
+                Path.Combine(_dir, "Test2.txt"),
+                Path.Combine(_dir, "Test1.xml"),
+            },
+            BackupDirectory = _dir,
+            CreateSubdirectories = true,
+            Cleanup = true,
+            DaysOlder = 14,
+            TaskExecutionId = Guid.NewGuid().ToString()
+        };
+        var result = Files.LocalBackup(input, default);
+        Assert.AreEqual(3, result.FileCountInBackup);
+    }
+
+    [TestMethod]
     public void TestBackup_FilePathsFilesNotFound()
     {
         var input = new Input

--- a/Frends.Files.LocalBackup/Frends.Files.LocalBackup.Tests/UnitTests.cs
+++ b/Frends.Files.LocalBackup/Frends.Files.LocalBackup.Tests/UnitTests.cs
@@ -11,7 +11,7 @@ namespace Frends.Files.LocalBackup.Tests;
 public class UnitTests
 {
     private readonly string _dir = Path.Combine(Environment.CurrentDirectory, "Tests"); // ...Test\bin\Debug\net6.0\
-    Input? paramInput;
+    Input? input;
 
     [TestInitialize]
     public void Setup()
@@ -33,7 +33,7 @@ public class UnitTests
     {
         var buDir = Path.Combine(_dir, "Backup");
 
-        paramInput = new Input()
+        input = new Input()
         {
             SourceDirectory = _dir,
             SourceFile = "*",
@@ -44,7 +44,7 @@ public class UnitTests
             CreateSubdirectories = false
         };
 
-        var result = Files.LocalBackup(paramInput, default);
+        var result = Files.LocalBackup(input, default);
         Assert.IsNotNull(result);
 
         foreach (var dir in Directory.GetDirectories(buDir))
@@ -65,7 +65,7 @@ public class UnitTests
     {
         var buDir = Path.Combine(_dir, "Backup");
 
-        paramInput = new Input()
+        input = new Input()
         {
             SourceDirectory = _dir,
             SourceFile = "*",
@@ -76,7 +76,7 @@ public class UnitTests
             CreateSubdirectories = true
         };
 
-        var result = Files.LocalBackup(paramInput, default);
+        var result = Files.LocalBackup(input, default);
         Assert.IsNotNull(result);
 
         foreach (var dir in Directory.GetDirectories(buDir, "2022-05-*"))
@@ -97,7 +97,7 @@ public class UnitTests
     {
         var buDir = Path.Combine(_dir, "Backup");
 
-        paramInput = new Input()
+        input = new Input()
         {
             SourceDirectory = _dir,
             SourceFile = "*",
@@ -108,7 +108,7 @@ public class UnitTests
             CreateSubdirectories = true
         };
 
-        var result = Files.LocalBackup(paramInput, default);
+        var result = Files.LocalBackup(input, default);
         Assert.IsNotNull(result);
 
         foreach (var dir in Directory.GetDirectories(buDir, "*qwerty123*"))
@@ -129,7 +129,7 @@ public class UnitTests
     {
         var buDir = Path.Combine(_dir, "Backup");
 
-        paramInput = new Input()
+        input = new Input()
         {
             SourceDirectory = _dir,
             SourceFile = "Test*",
@@ -139,7 +139,7 @@ public class UnitTests
             Cleanup = false,
         };
 
-        var result = Files.LocalBackup(paramInput, default);
+        var result = Files.LocalBackup(input, default);
         Assert.IsNotNull(result);
 
         foreach (var dir in Directory.GetDirectories(buDir, "2022-05-*"))
@@ -161,7 +161,7 @@ public class UnitTests
     {
         var buDir = Path.Combine(_dir, "Backup");
 
-        paramInput = new Input()
+        input = new Input()
         {
             SourceDirectory = _dir,
             SourceFile = "Test1.(txt|xml)",
@@ -171,7 +171,7 @@ public class UnitTests
             Cleanup = false,
         };
 
-        var result = Files.LocalBackup(paramInput, default);
+        var result = Files.LocalBackup(input, default);
         Assert.IsNotNull(result);
 
         foreach (var dir in Directory.GetDirectories(buDir, "2022-05-*"))
@@ -193,7 +193,7 @@ public class UnitTests
     {
         var buDir = Path.Combine(_dir, "Backup");
 
-        paramInput = new Input()
+        input = new Input()
         {
             SourceDirectory = _dir,
             SourceFile = "Test1.[^t][^x][^t]",
@@ -203,7 +203,7 @@ public class UnitTests
             Cleanup = false,
         };
 
-        var result = Files.LocalBackup(paramInput, default);
+        var result = Files.LocalBackup(input, default);
         Assert.IsNotNull(result);
 
         foreach (var dir in Directory.GetDirectories(buDir, "2022-05-*"))
@@ -225,7 +225,7 @@ public class UnitTests
     {
         var buDir = Path.Combine(_dir, "Backup", "Pro");
 
-        paramInput = new Input()
+        input = new Input()
         {
             SourceDirectory = Path.Combine(_dir, "Pro"),
             SourceFile = "<regex>^(?!prof).*_test.txt",
@@ -235,7 +235,7 @@ public class UnitTests
             Cleanup = false,
         };
 
-        var result = Files.LocalBackup(paramInput, default);
+        var result = Files.LocalBackup(input, default);
         Assert.IsNotNull(result);
 
         foreach (var dir in Directory.GetDirectories(buDir, "2022-05-*"))
@@ -259,7 +259,7 @@ public class UnitTests
         var backupDirectory = Path.Combine(_dir, "Cleanup", $"{timestampString}-{Guid.NewGuid()}");
         Directory.CreateDirectory(backupDirectory);
 
-        paramInput = new Input()
+        input = new Input()
         {
             SourceDirectory = _dir,
             SourceFile = "*",
@@ -270,7 +270,7 @@ public class UnitTests
             CreateSubdirectories = true,
         };
 
-        var result = Files.LocalBackup(paramInput, default);
+        var result = Files.LocalBackup(input, default);
         Assert.IsNotNull(result);
     }
 
@@ -280,7 +280,7 @@ public class UnitTests
     [TestMethod]
     public void CleanupFile_CreateSubdirectoriesFalse_Test()
     {
-        paramInput = new Input()
+        input = new Input()
         {
             SourceDirectory = _dir,
             SourceFile = "*",
@@ -295,7 +295,7 @@ public class UnitTests
         Directory.CreateDirectory(backupDirectory);
         Directory.SetLastWriteTimeUtc(backupDirectory, DateTime.Now.AddDays(-2));
 
-        var result = Files.LocalBackup(paramInput, default);
+        var result = Files.LocalBackup(input, default);
         Assert.IsNotNull(result);
         Assert.IsNotNull(result.Cleanups);
         Assert.IsFalse(Directory.Exists(backupDirectory));
@@ -309,7 +309,7 @@ public class UnitTests
     {
         var backup = Path.Combine(_dir, "Cleanup");
 
-        paramInput = new Input()
+        input = new Input()
         {
             SourceDirectory = _dir,
             SourceFile = "*",
@@ -320,7 +320,7 @@ public class UnitTests
             CreateSubdirectories = false,
         };
 
-        Files.LocalBackup(paramInput, default);
+        Files.LocalBackup(input, default);
         foreach (var dir in Directory.GetDirectories(backup))
             Directory.SetLastWriteTime(dir, DateTime.Now.AddDays(-2));
         var files = Directory.GetFiles(backup).ToList();
@@ -330,7 +330,7 @@ public class UnitTests
             var newName = Path.GetFileNameWithoutExtension(file) + "(1)" + Path.GetExtension(file);
             File.Move(file, Path.Combine(Path.GetDirectoryName(file) ?? backup, newName));
         }
-        var result = Files.LocalBackup(paramInput, default);
+        var result = Files.LocalBackup(input, default);
         Assert.AreEqual(4, result.Cleanups.Count);
     }
 
@@ -339,7 +339,7 @@ public class UnitTests
     {
         var backup = Path.Combine(_dir, "Cleanup");
 
-        paramInput = new Input()
+        input = new Input()
         {
             SourceDirectory = _dir,
             SourceFile = "*",
@@ -354,14 +354,14 @@ public class UnitTests
         var newDir = Path.Combine(backup, Guid.NewGuid().ToString());
         Directory.CreateDirectory(newDir);
         Directory.SetCreationTimeUtc(newDir, DateTime.UtcNow.AddDays(-2));
-        var result = Files.LocalBackup(paramInput, default);
+        var result = Files.LocalBackup(input, default);
         Assert.AreEqual(1, result.Cleanups.Count);
     }
 
     [TestMethod]
     public void TestCleanupWithoutBackup()
     {
-        var paramInput = new Input
+        var input = new Input
         {
             SourceDirectory = Environment.CurrentDirectory,
             SourceFile = "FileThatDontExist",
@@ -373,14 +373,14 @@ public class UnitTests
             TaskExecutionId = Guid.NewGuid().ToString()
         };
 
-        var result = Files.LocalBackup(paramInput, default);
+        var result = Files.LocalBackup(input, default);
         Assert.AreEqual(0, result.Cleanups.Count);
     }
 
     [TestMethod]
     public void TestBackupWithFilePaths()
     {
-        var paramInput = new Input
+        var input = new Input
         {
             SourceDirectory = "",
             SourceFile = "",
@@ -396,14 +396,14 @@ public class UnitTests
             DaysOlder = 14,
             TaskExecutionId = Guid.NewGuid().ToString()
         };
-        var result = Files.LocalBackup(paramInput, default);
+        var result = Files.LocalBackup(input, default);
         Assert.AreEqual(3, result.FileCountInBackup);
     }
 
     [TestMethod]
     public void TestBackup_OnlyFilePathsAreUsedEvenIfDirectoryAndFileMaskIsSet()
     {
-        var paramInput = new Input
+        var input = new Input
         {
             SourceDirectory = _dir,
             SourceFile = "*",
@@ -419,14 +419,14 @@ public class UnitTests
             DaysOlder = 14,
             TaskExecutionId = Guid.NewGuid().ToString()
         };
-        var result = Files.LocalBackup(paramInput, default);
+        var result = Files.LocalBackup(input, default);
         Assert.AreEqual(3, result.FileCountInBackup);
     }
 
     [TestMethod]
     public void TestBackup_FilePathsAsObjectArray()
     {
-        var paramInput = new Input
+        var input = new Input
         {
             SourceDirectory = _dir,
             SourceFile = "*",
@@ -442,14 +442,14 @@ public class UnitTests
             DaysOlder = 14,
             TaskExecutionId = Guid.NewGuid().ToString()
         };
-        var result = Files.LocalBackup(paramInput, default);
+        var result = Files.LocalBackup(input, default);
         Assert.AreEqual(3, result.FileCountInBackup);
     }
 
     [TestMethod]
     public void TestBackup_FilePathsFilesNotFound()
     {
-        var paramInput = new Input
+        var input = new Input
         {
             SourceDirectory = "",
             SourceFile = "",
@@ -465,7 +465,7 @@ public class UnitTests
             DaysOlder = 14,
             TaskExecutionId = Guid.NewGuid().ToString()
         };
-        var result = Files.LocalBackup(paramInput, default);
+        var result = Files.LocalBackup(input, default);
         Assert.AreEqual(0, result.FileCountInBackup);
     }
 
@@ -476,7 +476,7 @@ public class UnitTests
 
         Directory.CreateDirectory(Path.Combine(backup, Guid.NewGuid().ToString()));
 
-        var paramInput = new Input
+        var input = new Input
         {
             SourceDirectory = _dir,
             SourceFile = "*.8CO",
@@ -486,7 +486,7 @@ public class UnitTests
             TaskExecutionId = Guid.NewGuid().ToString()
         };
 
-        var result = Files.LocalBackup(paramInput, default);
+        var result = Files.LocalBackup(input, default);
         Assert.AreEqual(0, result.FileCountInBackup);
 
         Directory.Delete(backup, true);
@@ -497,7 +497,7 @@ public class UnitTests
     {
         var buDir = Path.Combine(_dir, "Backup");
 
-        paramInput = new Input()
+        input = new Input()
         {
             SourceDirectory = Path.Combine(_dir, "Special"),
             SourceFile = "p}ro(_tes[t.txt",
@@ -507,9 +507,9 @@ public class UnitTests
             Cleanup = false,
         };
 
-        var result = Files.LocalBackup(paramInput, default);
+        var result = Files.LocalBackup(input, default);
         Assert.AreEqual(1, result.Backups.Count);
-        Assert.IsTrue(File.Exists(Path.Combine(buDir, paramInput.SourceFile)));
+        Assert.IsTrue(File.Exists(Path.Combine(buDir, input.SourceFile)));
     }
 
     [TestMethod]
@@ -517,7 +517,7 @@ public class UnitTests
     {
         var buDir = Path.Combine(_dir, "Backup");
 
-        paramInput = new Input()
+        input = new Input()
         {
             SourceDirectory = _dir,
             SourceFile = "p}ro(_tes[t.txt",
@@ -527,9 +527,9 @@ public class UnitTests
             Cleanup = false,
         };
 
-        var result = Files.LocalBackup(paramInput, default);
+        var result = Files.LocalBackup(input, default);
         Assert.AreEqual(1, result.Backups.Count);
-        Assert.IsTrue(File.Exists(Path.Combine(buDir, paramInput.SourceFile)));
+        Assert.IsTrue(File.Exists(Path.Combine(buDir, input.SourceFile)));
     }
 
 
@@ -538,7 +538,7 @@ public class UnitTests
     {
         var buDir = Path.Combine(_dir, "Backup");
 
-        paramInput = new Input()
+        input = new Input()
         {
             SourceDirectory = _dir,
             SourceFile = "*.txt",
@@ -548,7 +548,7 @@ public class UnitTests
             Cleanup = false,
         };
 
-        var result = Files.LocalBackup(paramInput, default);
+        var result = Files.LocalBackup(input, default);
         Assert.AreEqual(3, result.Backups.Count);
     }
 
@@ -557,7 +557,7 @@ public class UnitTests
     {
         var buDir = Path.Combine(_dir, "Backup");
 
-        paramInput = new Input()
+        input = new Input()
         {
             SourceDirectory = _dir,
             SourceFile = "p}ro(_tes[*",
@@ -567,7 +567,7 @@ public class UnitTests
             Cleanup = false,
         };
 
-        var result = Files.LocalBackup(paramInput, default);
+        var result = Files.LocalBackup(input, default);
         Assert.AreEqual(1, result.Backups.Count);
     }
 
@@ -576,7 +576,7 @@ public class UnitTests
     {
         var buDir = Path.Combine(_dir, "Backup");
 
-        paramInput = new Input()
+        input = new Input()
         {
             SourceDirectory = _dir,
             SourceFile = "*}ro(_tes[t.txt",
@@ -586,7 +586,7 @@ public class UnitTests
             Cleanup = false,
         };
 
-        var result = Files.LocalBackup(paramInput, default);
+        var result = Files.LocalBackup(input, default);
         Assert.AreEqual(1, result.Backups.Count);
     }
 

--- a/Frends.Files.LocalBackup/Frends.Files.LocalBackup/Frends.Files.LocalBackup.csproj
+++ b/Frends.Files.LocalBackup/Frends.Files.LocalBackup/Frends.Files.LocalBackup.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
 	<TargetFrameworks>net6.0;netstandard2.0;net471</TargetFrameworks>
 	<LangVersion>Latest</LangVersion>
-	<Version>2.1.2</Version>
+	<Version>2.1.3</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.Files.LocalBackup/Frends.Files.LocalBackup/LocalBackup.cs
+++ b/Frends.Files.LocalBackup/Frends.Files.LocalBackup/LocalBackup.cs
@@ -96,22 +96,17 @@ namespace Frends.Files.LocalBackup
                 if (Directory.Exists(backupDirectory))
                 {
                     var directories = Directory.GetDirectories(backupDirectory);
-                    foreach (var dir in directories)
+
+                    foreach (var dir in directories.Where(d => Directory.GetLastWriteTime(d) < DateTime.Now.AddDays(-input.DaysOlder)))
                     {
-                        if (Directory.GetLastWriteTime(dir) < DateTime.Now.AddDays(-input.DaysOlder))
-                        {
-                            Directory.Delete(dir, true);
-                            result.Add($"{dir} deleted.");
-                        }
+                        Directory.Delete(dir, true);
+                        result.Add($"{dir} deleted.");
                     }
                     var files = Directory.GetFiles(backupDirectory);
-                    foreach (var file in files)
+                    foreach (var file in files.Where(f => File.GetLastWriteTime(f) < DateTime.Now.AddDays(-input.DaysOlder)))
                     {
-                        if (File.GetLastWriteTime(file) < DateTime.Now.AddDays(-input.DaysOlder))
-                        {
-                            File.Delete(file);
-                            result.Add($"{file} deleted.");
-                        }
+                        File.Delete(file);
+                        result.Add($"{file} deleted.");
                     }
                 }
             }
@@ -189,9 +184,12 @@ namespace Frends.Files.LocalBackup
         private static string[] ConvertObjectToStringArray(object objectArray)
         {
             if (!objectArray.GetType().IsArray)
-            throw new ArgumentException($"Invalid type for parameter FilePaths. Expected array but was {objectArray.GetType()}");
-        var res = objectArray as object[];
-        return res.OfType<string>().ToArray();
+                throw new ArgumentException($"Invalid type for parameter FilePaths. Expected array but was {objectArray.GetType()}");
+
+            var res = objectArray as object[];
+            if (res == null)
+                return null;
+            return res.OfType<string>().ToArray();
         }
     }
 }

--- a/Frends.Files.LocalBackup/Frends.Files.LocalBackup/LocalBackup.cs
+++ b/Frends.Files.LocalBackup/Frends.Files.LocalBackup/LocalBackup.cs
@@ -50,7 +50,7 @@ namespace Frends.Files.LocalBackup
 
             if (input.FilePaths != null)
             {
-                files = (string[])input.FilePaths;
+                files = ConvertObjectToStringArray(input.FilePaths);
                 foreach (string file in files)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
@@ -184,6 +184,14 @@ namespace Frends.Files.LocalBackup
                     return true;
                 return false;
             }
+        }
+
+        private static string[] ConvertObjectToStringArray(object objectArray)
+        {
+            if (!objectArray.GetType().IsArray)
+            throw new ArgumentException($"Invalid type for parameter FilePaths. Expected array but was {objectArray.GetType()}");
+        var res = objectArray as object[];
+        return res.OfType<string>().ToArray();
         }
     }
 }


### PR DESCRIPTION
#61 
## [2.1.3] - 2024-01-15
### Fixed
- Fixed how FilePaths were handled. Changed casting to string[] to convert the object into a string[] by casting it first as a object[].