### PR TITLE
Files.Read fixed issue-69

### DIFF
--- a/Frends.Files.Read/CHANGELOG.md
+++ b/Frends.Files.Read/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.1.0] - 2024-10-14
+### Fixed
+- Fixed documentation for Path parameter.
+### Added
+- Added Windows1252 encoding to the FileEncoding enum.
+- Added different sizes to the Task result.
+
 ## [1.0.0] - 2023-02-28
 ### Added
 - Initial implementation

--- a/Frends.Files.Read/Frends.Files.Read.Tests/ImpersonationTests.cs
+++ b/Frends.Files.Read/Frends.Files.Read.Tests/ImpersonationTests.cs
@@ -61,7 +61,7 @@ class ImpersonationTests
     }
 
     [Test]
-    public async Task FileMoveTestWithCredentials()
+    public async Task FileReadTestWithCredentials()
     {
         var result = await Files.Read(_input, _options);
 
@@ -70,7 +70,7 @@ class ImpersonationTests
     }
 
     [Test]
-    public void FileMoveTestWithUsernameWithoutDomain()
+    public void FileReadTestWithUsernameWithoutDomain()
     {
         var options = new Options
         {

--- a/Frends.Files.Read/Frends.Files.Read.Tests/TestFiles/folder/test.txt
+++ b/Frends.Files.Read/Frends.Files.Read.Tests/TestFiles/folder/test.txt
@@ -1,0 +1,1 @@
+This is test file

--- a/Frends.Files.Read/Frends.Files.Read/Definitions/FileEncoding.cs
+++ b/Frends.Files.Read/Frends.Files.Read/Definitions/FileEncoding.cs
@@ -8,8 +8,9 @@ namespace Frends.Files.Read.Definitions;
 public enum FileEncoding
 {
     UTF8,
-    ANSI,
+    Default,
     ASCII,
     Unicode,
+    Windows1252,
     Other
 }

--- a/Frends.Files.Read/Frends.Files.Read/Definitions/Input.cs
+++ b/Frends.Files.Read/Frends.Files.Read/Definitions/Input.cs
@@ -8,7 +8,7 @@ namespace Frends.Files.Read.Definitions;
 public class Input
 {
     /// <summary>
-    /// Full path of the target file to be written
+    /// Full path of the target file to be read.
     /// </summary>
     /// <example>c:\temp\foo.txt</example>
     [DisplayFormat(DataFormatString = "Text")]

--- a/Frends.Files.Read/Frends.Files.Read/Definitions/Result.cs
+++ b/Frends.Files.Read/Frends.Files.Read/Definitions/Result.cs
@@ -26,6 +26,18 @@ public class Result
     public double SizeInMegaBytes { get; private set; }
 
     /// <summary>
+    /// Size of the written file in kilo bytes.
+    /// </summary>
+    /// <example>32</example>
+    public double SizeInKiloBytes { get; private set; }
+
+    /// <summary>
+    /// Size of the written file in bytes.
+    /// </summary>
+    /// <example>32</example>
+    public double SizeInBytes { get; private set; }
+
+    /// <summary>
     /// DateTime when file was created.
     /// </summary>
     /// <example>2023-01-31T12:54:17.6431957+02:00</example>
@@ -42,6 +54,8 @@ public class Result
         Content = content;
         Path = info.FullName;
         SizeInMegaBytes = Math.Round(info.Length / 1024d / 1024d, 3);
+        SizeInKiloBytes = Math.Round(info.Length / 1024d, 3);
+        SizeInBytes = info.Length;
         CreationTime = info.CreationTime;
         LastWriteTime = info.LastWriteTime;
     }

--- a/Frends.Files.Read/Frends.Files.Read/Frends.Files.Read.csproj
+++ b/Frends.Files.Read/Frends.Files.Read/Frends.Files.Read.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
 	<TargetFramework>net6.0</TargetFramework>
 	<LangVersion>Latest</LangVersion>
-	<Version>1.0.0</Version>
+	<Version>1.1.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.Files.Read/Frends.Files.Read/Read.cs
+++ b/Frends.Files.Read/Frends.Files.Read/Read.cs
@@ -17,7 +17,7 @@ namespace Frends.Files.Read;
 public class Files
 {
     /// <summary>
-    /// Read file.
+    /// Reads a file from directory.
     /// [Documentation](https://tasks.frends.com/tasks/frends-tasks/Frends.Files.Read)
     /// </summary>
     /// <param name="input">Input parameters</param>
@@ -69,20 +69,15 @@ public class Files
 
     private static Encoding GetEncoding(FileEncoding optionsFileEncoding, bool optionsEnableBom, string optionsEncodingInString)
     {
-        switch (optionsFileEncoding)
+        return optionsFileEncoding switch
         {
-            case FileEncoding.Other:
-                return Encoding.GetEncoding(optionsEncodingInString);
-            case FileEncoding.ASCII:
-                return Encoding.ASCII;
-            case FileEncoding.ANSI:
-                return Encoding.Default;
-            case FileEncoding.UTF8:
-                return optionsEnableBom ? new UTF8Encoding(true) : new UTF8Encoding(false);
-            case FileEncoding.Unicode:
-                return Encoding.Unicode;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+            FileEncoding.Other => Encoding.GetEncoding(optionsEncodingInString),
+            FileEncoding.ASCII => Encoding.ASCII,
+            FileEncoding.Default => Encoding.Default,
+            FileEncoding.UTF8 => optionsEnableBom ? new UTF8Encoding(true) : new UTF8Encoding(false),
+            FileEncoding.Windows1252 => Encoding.GetEncoding("windows-1252"),
+            FileEncoding.Unicode => Encoding.Unicode,
+            _ => throw new ArgumentOutOfRangeException(),
+        };
     }
 }

--- a/Frends.Files.Read/Frends.Files.Read/Read.cs
+++ b/Frends.Files.Read/Frends.Files.Read/Read.cs
@@ -79,7 +79,7 @@ public class Files
                 return Encoding.Default;
             case FileEncoding.UTF8:
                 return optionsEnableBom ? new UTF8Encoding(true) : new UTF8Encoding(false);
-            case FileEncoding.Windows1252: 
+            case FileEncoding.Windows1252:
                 EncodingProvider provider = CodePagesEncodingProvider.Instance;
                 Encoding.RegisterProvider(provider);
                 return Encoding.GetEncoding(1252);

--- a/Frends.Files.Read/Frends.Files.Read/Read.cs
+++ b/Frends.Files.Read/Frends.Files.Read/Read.cs
@@ -69,15 +69,24 @@ public class Files
 
     private static Encoding GetEncoding(FileEncoding optionsFileEncoding, bool optionsEnableBom, string optionsEncodingInString)
     {
-        return optionsFileEncoding switch
+        switch (optionsFileEncoding)
         {
-            FileEncoding.Other => Encoding.GetEncoding(optionsEncodingInString),
-            FileEncoding.ASCII => Encoding.ASCII,
-            FileEncoding.Default => Encoding.Default,
-            FileEncoding.UTF8 => optionsEnableBom ? new UTF8Encoding(true) : new UTF8Encoding(false),
-            FileEncoding.Windows1252 => Encoding.GetEncoding("windows-1252"),
-            FileEncoding.Unicode => Encoding.Unicode,
-            _ => throw new ArgumentOutOfRangeException(),
-        };
+            case FileEncoding.Other:
+                return Encoding.GetEncoding(optionsEncodingInString);
+            case FileEncoding.ASCII:
+                return Encoding.ASCII;
+            case FileEncoding.Default:
+                return Encoding.Default;
+            case FileEncoding.UTF8:
+                return optionsEnableBom ? new UTF8Encoding(true) : new UTF8Encoding(false);
+            case FileEncoding.Windows1252: 
+                EncodingProvider provider = CodePagesEncodingProvider.Instance;
+                Encoding.RegisterProvider(provider);
+                return Encoding.GetEncoding(1252);
+            case FileEncoding.Unicode:
+                return Encoding.Unicode;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
     }
 }


### PR DESCRIPTION
#69 

## [1.1.0] - 2024-10-14
### Fixed
- Fixed documentation for Path parameter.
### Added
- Added Windows1252 encoding to the FileEncoding enum.
- Added different sizes to the Task result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for Windows1252 encoding in file reading operations.
	- Introduced new properties for file size in the Task result: SizeInKiloBytes and SizeInBytes.
  
- **Bug Fixes**
	- Corrected documentation for the Path parameter to clarify its purpose.

- **Documentation**
	- Enhanced documentation for the Read method and updated the Input class documentation.

- **Refactor**
	- Improved encoding selection logic for better clarity and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->