### PR TITLE
Files.Move - Fixed issue with impersonation

### DIFF
--- a/Frends.Files.Move/CHANGELOG.md
+++ b/Frends.Files.Move/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.0] - 2024-11-1
+### Fixed
+- Fixed issue with Task not working with impersonation by removing the source file in the main method.
+
 ## [1.0.0] - 2023-02-14
 ### Added
 - Initial implementation

--- a/Frends.Files.Move/Frends.Files.Move.Tests/ImpersonationTests.cs
+++ b/Frends.Files.Move/Frends.Files.Move.Tests/ImpersonationTests.cs
@@ -70,6 +70,8 @@ class ImpersonationTests
             _options, default);
 
         Assert.AreEqual(7, result.Files.Count);
+        Assert.IsTrue(File.Exists(result.Files[0].TargetPath));
+        Assert.IsFalse(File.Exists(result.Files[0].SourcePath));
     }
 
     [Test]

--- a/Frends.Files.Move/Frends.Files.Move.Tests/UnitTests.cs
+++ b/Frends.Files.Move/Frends.Files.Move.Tests/UnitTests.cs
@@ -50,6 +50,7 @@ public class UnitTests
 
         Assert.AreEqual(7, result.Files.Count);
         Assert.IsTrue(File.Exists(result.Files[0].TargetPath));
+        Assert.IsFalse(File.Exists(result.Files[0].SourcePath));
     }
 
     [Test]
@@ -66,6 +67,7 @@ public class UnitTests
 
         Assert.AreEqual(7, result.Files.Count);
         Assert.IsTrue(File.Exists(result.Files[0].TargetPath));
+        Assert.IsFalse(File.Exists(result.Files[0].SourcePath));
     }
 
     [Test]
@@ -85,6 +87,7 @@ public class UnitTests
 
         Assert.AreEqual(7, result.Files.Count);
         Assert.IsTrue(File.Exists(result.Files[0].TargetPath));
+        Assert.IsFalse(File.Exists(result.Files[0].SourcePath));
     }
 
     [Test]
@@ -99,6 +102,8 @@ public class UnitTests
             }, _options, default);
 
         Assert.AreEqual(2, result.Files.Count);
+        Assert.IsTrue(File.Exists(result.Files[0].TargetPath));
+        Assert.IsFalse(File.Exists(result.Files[0].SourcePath));
     }
 
     [Test]

--- a/Frends.Files.Move/Frends.Files.Move/Frends.Files.Move.csproj
+++ b/Frends.Files.Move/Frends.Files.Move/Frends.Files.Move.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
 	<TargetFramework>net6.0</TargetFramework>
 	<LangVersion>Latest</LangVersion>
-	<Version>1.0.0</Version>
+	<Version>1.1.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.Files.Move/Frends.Files.Move/Move.cs
+++ b/Frends.Files.Move/Frends.Files.Move/Move.cs
@@ -29,10 +29,8 @@ public class Files
     /// <returns>Result object { List&lt;FileItem&gt; }</returns>
     public static async Task<Result> Move([PropertyTab] Input input, [PropertyTab] Options options, CancellationToken cancellationToken)
     {
-        var result = await ExecuteActionAsync(() => ExecuteCopyAsync(input, options, cancellationToken),
+        var result = await ExecuteActionAsync(() => ExecuteMoveAsync(input, options, cancellationToken),
             options.UseGivenUserCredentialsForRemoteConnections, options.UserName, options.Password).ConfigureAwait(false);
-
-        DeleteExistingFiles(result.Select(x => x.SourcePath));
 
         return new Result(result);
     }
@@ -54,7 +52,7 @@ public class Files
 
     }
 
-    private static async Task<List<FileItem>> ExecuteCopyAsync(Input input, Options options, CancellationToken cancellationToken)
+    private static async Task<List<FileItem>> ExecuteMoveAsync(Input input, Options options, CancellationToken cancellationToken)
     {
         var results = FindMatchingFiles(input.Directory, input.Pattern);
         var fileTransferEntries = GetFileTransferEntries(results.Files, input.Directory, input.TargetDirectory, options.PreserveDirectoryStructure);
@@ -107,6 +105,7 @@ public class Files
             throw;
         }
 
+        DeleteExistingFiles(fileResults.Select(x => x.SourcePath));
         return fileResults;
     }
 


### PR DESCRIPTION
#65 

## [1.1.0] - 2024-11-1
### Fixed
- Fixed issue with Task not working with impersonation by removing the source file in the main method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced functionality for moving files instead of copying them, enhancing file management.
  
- **Bug Fixes**
  - Resolved an issue with task functionality during impersonation, ensuring proper operation.

- **Tests**
  - Enhanced test coverage with new assertions to verify file existence post-move and validate error handling for incorrect username formats.

- **Chores**
  - Updated project version to 1.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->