### PR TITLE
Files.Copy - Add new option ThrowErrorOnFail

### DIFF
--- a/Frends.Files.Copy/CHANGELOG.md
+++ b/Frends.Files.Copy/CHANGELOG.md
@@ -1,20 +1,20 @@
 # Changelog
 
-# [1.2.0] - 2025-04-08
+## [1.2.0] - 2025-04-08
 ### Added
 - New option ThrowErrorOnFail to allow task to continue despite some files failing to copy.
-	- Files that failed to copy will be listed in the Result.FailedFiles property.
-	- When set to false and IfTargetFileExists is set to Throw, the task will continue copying other files despite a error.
+  - Files that failed to copy will be listed in the Result.FailedFiles property.
+  - When set to false and IfTargetFileExists is set to Throw, the task will continue copying other files despite an error.
 
-# [1.1.0] - 2025-03-13
+## [1.1.0] - 2025-03-13
 ### Fixed
 - Fixed bug where regex patterns were not handled correctly in file matching.
 
-# [1.0.2] - 2023-11-27
+## [1.0.2] - 2023-11-27
 ### Changed
 - Documentational changes.
 
-# [1.0.1] - 2023-09-21
+## [1.0.1] - 2023-09-21
 ### Fixed
 - Fixed bug with file access. Changed File.Open to use FileAccess.Read, because there's no reason to give more access to the Task.
 

--- a/Frends.Files.Copy/CHANGELOG.md
+++ b/Frends.Files.Copy/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# [1.2.0] - 2025-04-08
+### Added
+- New option ThrowErrorOnFail to allow task to continue despite some files failing to copy.
+	- Files that failed to copy will be listed in the Result.FailedFiles property.
+	- When set to false and IfTargetFileExists is set to Throw, the task will continue copying other files despite a error.
+
 # [1.1.0] - 2025-03-13
 ### Fixed
 - Fixed bug where regex patterns were not handled correctly in file matching.

--- a/Frends.Files.Copy/Frends.Files.Copy.Tests/UnitTests.cs
+++ b/Frends.Files.Copy/Frends.Files.Copy.Tests/UnitTests.cs
@@ -33,7 +33,8 @@ public class UnitTests
             UseGivenUserCredentialsForRemoteConnections = false,
             PreserveDirectoryStructure = true,
             CreateTargetDirectories = false,
-            IfTargetFileExists = FileExistsAction.Throw
+            IfTargetFileExists = FileExistsAction.Throw,
+            ThrowErrorOnFail = true,
         };
     }
 
@@ -176,5 +177,28 @@ public class UnitTests
         );
 
         Assert.AreEqual(3, result.Files.Count);
+    }
+
+    [Test]
+    public async Task FileCopyShouldNotThrowIfThrowErrorOnFailIsFalse()
+    {
+        var testFile = "prof_test.txt";
+
+        var options = new Options
+        {
+            UseGivenUserCredentialsForRemoteConnections = false,
+            PreserveDirectoryStructure = true,
+            CreateTargetDirectories = false,
+            IfTargetFileExists = FileExistsAction.Throw,
+            ThrowErrorOnFail = false,
+        };
+
+        File.Copy(Path.Combine(_SourceDir, testFile), Path.Combine(_TargetDir, testFile));
+
+        var result = await Files.Copy(_input, options, default);
+
+        Assert.IsTrue(File.Exists(result.Files[0].TargetPath));
+        Assert.AreEqual(1, result.FailedFiles.Count);
+        Assert.AreEqual(Path.Combine(_SourceDir, testFile), result.FailedFiles[0].SourcePath);
     }
 }

--- a/Frends.Files.Copy/Frends.Files.Copy/Copy.cs
+++ b/Frends.Files.Copy/Frends.Files.Copy/Copy.cs
@@ -169,10 +169,6 @@ public class Files
         var duplicateTargetPaths = GetDuplicateValues(filePaths);
         if (duplicateTargetPaths.Any())
             throw new IOException($"Multiple files written to {string.Join(", ", duplicateTargetPaths)}. The files would get overwritten. No files copied.");
-
-        foreach (var targetFilePath in filePaths)
-            if (File.Exists(targetFilePath))
-                throw new IOException($"File '{targetFilePath}' already exists. No files copied.");
     }
 
     private static IList<string> GetDuplicateValues(IEnumerable<string> values)

--- a/Frends.Files.Copy/Frends.Files.Copy/Copy.cs
+++ b/Frends.Files.Copy/Frends.Files.Copy/Copy.cs
@@ -27,7 +27,7 @@ public class Files
     /// <param name="input">Input parameters for the Task.</param>
     /// <param name="options">Additional options for the Task.</param>
     /// <param name="cancellationToken">CancellationToken given by Frends.</param>
-    /// <returns>Object { List&lt;Object { string SourcePath, string TargetPath }&gt; Files } ]</returns>
+    /// <returns>Object { List&lt;Object { string SourcePath, string TargetPath }&gt; Files, List&lt;Object { string SourcePath, Exception Exception }&gt; FailedFiles }</returns>
     public static async Task<Result> Copy([PropertyTab] Input input, [PropertyTab] Options options, CancellationToken cancellationToken)
     {
         var (files, failed) = await ExecuteActionAsync(() => ExecuteCopyAsync(input, options, cancellationToken),

--- a/Frends.Files.Copy/Frends.Files.Copy/Definitions/FailedFileItem.cs
+++ b/Frends.Files.Copy/Frends.Files.Copy/Definitions/FailedFileItem.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Frends.Files.Copy.Definitions;
+
+/// <summary>
+/// Represents a file that failed to copy.
+/// </summary>
+public class FailedFileItem
+{
+    /// <summary>
+    /// Path of the source file.
+    /// </summary>
+    public string SourcePath { get; set; }
+
+    /// <summary>
+    /// Exception that caused the copy to fail.
+    /// </summary>
+    public Exception Exception { get; set; }
+
+    internal FailedFileItem(string sourcePath, Exception exception)
+    {
+        SourcePath = sourcePath;
+        Exception = exception;
+    }
+}

--- a/Frends.Files.Copy/Frends.Files.Copy/Definitions/Options.cs
+++ b/Frends.Files.Copy/Frends.Files.Copy/Definitions/Options.cs
@@ -59,9 +59,10 @@ public class Options
 
     /// <summary>
     /// Whether to throw an error on a failure to copy a file.
+    /// This option is independent of the <see cref="IfTargetFileExists"/> option with the value of <see cref="FileExistsAction.Throw"/> and will affect handling of all errors during the copy process.
     /// If set to false, task will continue executing despite files failing to copy, otherwise execution will stop at the first failure.
-    /// Note:
-    /// When set to false and <see cref="IfTargetFileExists"/> is set to <see cref="FileExistsAction.Throw"/>, the task will continue copying other files despite a failure. 
+    /// 
+    /// Note: When set to false and <see cref="IfTargetFileExists"/> is set to <see cref="FileExistsAction.Throw"/>, the task will continue copying other files despite a failure.
     /// Behaviour of <see cref="FileExistsAction.Overwrite"/> and <see cref="FileExistsAction.Rename"/> will not be affected by this setting.
     /// </summary>
     /// <example>true</example>

--- a/Frends.Files.Copy/Frends.Files.Copy/Definitions/Options.cs
+++ b/Frends.Files.Copy/Frends.Files.Copy/Definitions/Options.cs
@@ -56,5 +56,13 @@ public class Options
     /// </summary>
     /// <example>FileExistsAction.Overwrite</example>
     public FileExistsAction IfTargetFileExists { get; set; }
+
+    /// <summary>
+    /// Whether to throw an error on a failure to copy a file. 
+    /// If set to false, task will continue executing despite files failing to copy, otherwise execution will stop on the first failure.
+    /// </summary>
+    /// <example>false</example>
+    [DefaultValue(true)]
+    public bool ThrowErrorOnFail { get; set; }
 }
 

--- a/Frends.Files.Copy/Frends.Files.Copy/Definitions/Options.cs
+++ b/Frends.Files.Copy/Frends.Files.Copy/Definitions/Options.cs
@@ -58,11 +58,13 @@ public class Options
     public FileExistsAction IfTargetFileExists { get; set; }
 
     /// <summary>
-    /// Whether to throw an error on a failure to copy a file. 
-    /// If set to false, task will continue executing despite files failing to copy, otherwise execution will stop on the first failure.
+    /// Whether to throw an error on a failure to copy a file.
+    /// If set to false, task will continue executing despite files failing to copy, otherwise execution will stop at the first failure.
+    /// Note:
+    /// When set to false and <see cref="IfTargetFileExists"/> is set to <see cref="FileExistsAction.Throw"/>, the task will continue copying other files despite a failure. 
+    /// Behaviour of <see cref="FileExistsAction.Overwrite"/> and <see cref="FileExistsAction.Rename"/> will not be affected by this setting.
     /// </summary>
-    /// <example>false</example>
+    /// <example>true</example>
     [DefaultValue(true)]
     public bool ThrowErrorOnFail { get; set; }
 }
-

--- a/Frends.Files.Copy/Frends.Files.Copy/Definitions/Result.cs
+++ b/Frends.Files.Copy/Frends.Files.Copy/Definitions/Result.cs
@@ -15,6 +15,7 @@ public class Result
 
     /// <summary>
     /// List of FailedItems including path of the source file and failure exception.
+    /// This list will always be empty unless <see cref="Options.ThrowErrorOnFail"/> is set to false.
     /// </summary>
     /// <example>[object {SourcePath: C:\test\testfolder\test1.txt, Exception: object {Message: Unable to create 'C:\test\moved' directory}}, object {SourcePath: C:\test\testfolder\test2.txt, Exception: object {Message: File 'C:\test\moved\test2.txt' already exists}}]</example>
     public List<FailedFileItem> FailedFiles { get; private set; }

--- a/Frends.Files.Copy/Frends.Files.Copy/Definitions/Result.cs
+++ b/Frends.Files.Copy/Frends.Files.Copy/Definitions/Result.cs
@@ -13,8 +13,15 @@ public class Result
     /// <example>[object {SourcePath: C:\test\testfolder\test1.txt, TargetPath: C:\test\moved\test1.txt}, object {SourcePath: C:\test\testfolder\test2.txt, TargetPath: C:\test\moved\test2.txt}]</example>
     public List<FileItem> Files { get; private set; }
 
-    internal Result(List<FileItem> files)
+    /// <summary>
+    /// List of FailedItems including path of the source file and failure exception.
+    /// </summary>
+    /// <example>[object {SourcePath: C:\test\testfolder\test1.txt, Exception: object {Message: Unable to create 'C:\test\moved' directory}}, object {SourcePath: C:\test\testfolder\test2.txt, Exception: object {Message: File 'C:\test\moved\test2.txt' already exists}}]</example>
+    public List<FailedFileItem> FailedFiles { get; private set; }
+
+    internal Result(List<FileItem> files, List<FailedFileItem> failedFiles)
     {
         Files = files;
+        FailedFiles = failedFiles;
     }
 }

--- a/Frends.Files.Copy/Frends.Files.Copy/Frends.Files.Copy.csproj
+++ b/Frends.Files.Copy/Frends.Files.Copy/Frends.Files.Copy.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
 	<TargetFramework>net6.0</TargetFramework>
 	<LangVersion>Latest</LangVersion>
-	<Version>1.1.0</Version>
+	<Version>1.2.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>


### PR DESCRIPTION
Add option to continue execution after an exception is thrown. Files that failed to copy will be listed in `FailedFiles` with the exception that caused the failure.

Closes #76 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a `ThrowErrorOnFail` option for file copying, allowing users to decide whether to halt on the first failure or continue processing.
  - Enhanced reporting of file copy operations, now providing details on both successful and failed transfers through the `Result` object.

- **Bug Fixes**
  - Improved error handling during file copy operations to ensure that failures are logged without stopping the process when configured to do so.

- **Chores**
  - Updated project version from `1.1.0` to `1.2.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->