### PR TITLE
Implemented RemotePathType for credential separation.

### DIFF
--- a/Frends.Files.Move/Frends.Files.Move.Tests/Frends.Files.Move.Tests.csproj
+++ b/Frends.Files.Move/Frends.Files.Move.Tests/Frends.Files.Move.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+	<PackageReference Include="Docker.DotNet" Version="3.125.15" />
 	<PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
 	<PackageReference Include="nunit" Version="4.3.2" />
 	<PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />

--- a/Frends.Files.Move/Frends.Files.Move.Tests/ImpersonationTests.cs
+++ b/Frends.Files.Move/Frends.Files.Move.Tests/ImpersonationTests.cs
@@ -38,7 +38,7 @@ class ImpersonationTests
 
         _options = new Options
         {
-            UseGivenUserCredentialsForRemoteConnections = true,
+            //UseGivenUserCredentialsForRemoteConnections = true,
             UserName = $"{_domain}\\{_name}",
             Password = _pwd
         };
@@ -80,7 +80,7 @@ class ImpersonationTests
     {
         var options = new Options
         {
-            UseGivenUserCredentialsForRemoteConnections = true,
+            //UseGivenUserCredentialsForRemoteConnections = true,
             UserName = "test",
             Password = _pwd
         };

--- a/Frends.Files.Move/Frends.Files.Move.Tests/Samba/ImpersonationSambaDockerTests.cs
+++ b/Frends.Files.Move/Frends.Files.Move.Tests/Samba/ImpersonationSambaDockerTests.cs
@@ -1,0 +1,292 @@
+﻿using Frends.Files.Move.Definitions;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Frends.Files.Move.Tests.Samba;
+
+[TestFixture]
+public class ImpersonationSambaDockerTests
+{
+    private string _localSourceDir;
+    private string _localTargetDir;
+    private string _remoteDir;
+    private Options _options;
+    private bool _isDockerEnvironment;
+
+    [OneTimeSetUp]
+    public void OneTimeSetup()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), "ImpersonationDockerTests_" + Guid.NewGuid().ToString("N")[..8]);
+        _localSourceDir = Path.Combine(tempRoot, "Source");
+        _localTargetDir = Path.Combine(tempRoot, "Target");
+        Directory.CreateDirectory(_localSourceDir);
+        Directory.CreateDirectory(_localTargetDir);
+
+        WaitForDockerContainer("impersonation_test_samba", TimeSpan.FromMinutes(2));
+
+        var connectionMethods = new[]
+        {
+            @"\\localhost:1445\testshare",      // Docker port mapping
+            @"\\127.0.0.1:1445\testshare",     // Localhost IP with port
+            GetContainerDirectPath(),           // Container IP fallback
+            @"\\host.docker.internal:1445\testshare"  // Docker Desktop host
+        };
+
+        _isDockerEnvironment = false;
+        string lastError = "";
+
+        foreach (var path in connectionMethods)
+        {
+            if (string.IsNullOrEmpty(path)) continue;
+
+            try
+            {
+                if (TestSambaConnection(path, "testuser", "password123!", TimeSpan.FromSeconds(10)))
+                {
+                    _remoteDir = path;
+                    _isDockerEnvironment = true;
+                    break;
+                }
+            }
+            catch (Exception ex)
+            {
+                lastError = ex.Message;
+                continue;
+            }
+        }
+
+        if (!_isDockerEnvironment)
+        {
+            Assert.Ignore("Docker Samba environment not available");
+        }
+
+        _options = new Options
+        {
+            UserName = @"WORKGROUP\testuser",
+            Password = "password123!",
+            CreateTargetDirectories = true,
+            IfTargetFileExists = FileExistsAction.Overwrite
+        };
+    }
+
+    private void WaitForDockerContainer(string containerName, TimeSpan timeout)
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        while (stopwatch.Elapsed < timeout)
+        {
+            try
+            {
+                var psi = new ProcessStartInfo("docker", $"exec {containerName} smbclient -L //localhost/ -U testuser%password123! --option=\"client min protocol=SMB2\"")
+                {
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+
+                using var process = Process.Start(psi);
+                if (process.WaitForExit(5000) && process.ExitCode == 0)
+                {
+                    return;
+                }
+            }
+            catch { }
+
+            Console.WriteLine($"⏳ Waiting for container {containerName} to be ready... ({stopwatch.Elapsed.TotalSeconds:F0}s)");
+            Thread.Sleep(2000);
+        }
+    }
+
+    private string GetContainerDirectPath()
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("docker", "inspect impersonation_test_samba -f \"{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var process = Process.Start(psi);
+            if (process.WaitForExit(5000) && process.ExitCode == 0)
+            {
+                var ip = process.StandardOutput.ReadToEnd().Trim();
+                if (!string.IsNullOrEmpty(ip) && ip != "localhost")
+                {
+                    return $@"\\{ip}\testshare";
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Failed to get container IP: {ex.Message}");
+        }
+
+        return null;
+    }
+
+    private bool TestSambaConnection(string uncPath, string username, string password, TimeSpan timeout)
+    {
+        var host = ExtractHostFromUncPath(uncPath);
+
+        var psi = new ProcessStartInfo("docker", $"exec impersonation_test_samba smbclient //{host}/testshare -U {username}%{password} -c dir")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var process = Process.Start(psi);
+        return process.WaitForExit((int)timeout.TotalMilliseconds) && process.ExitCode == 0;
+    }
+
+    private string ExtractHostFromUncPath(string uncPath)
+    {
+        // Extract host
+        var parts = uncPath.TrimStart('\\').Split('\\');
+        return parts.Length > 0 ? parts[0] : "localhost";
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        var tempRoot = Path.GetDirectoryName(_localSourceDir);
+        if (Directory.Exists(tempRoot))
+        {
+            Directory.Delete(tempRoot, true);
+        }
+    }
+
+    [SetUp]
+    public void Setup()
+    {
+        Helper.CreateTestFiles(_localSourceDir);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_localTargetDir))
+        {
+            Helper.DeleteTestFolder(_localTargetDir);
+            Directory.CreateDirectory(_localTargetDir);
+        }
+
+        if (Directory.Exists(_localSourceDir))
+        {
+            Helper.DeleteTestFolder(_localSourceDir);
+            Directory.CreateDirectory(_localSourceDir);
+        }
+        try
+        {
+            CleanRemoteDirectory();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Warning: Failed to clean remote directory: {ex.Message}");
+        }
+    }
+
+    private void CleanRemoteDirectory()
+    {
+        var psi = new ProcessStartInfo("docker", $"exec impersonation_test_samba find /mount/testshare -type f -delete")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var process = Process.Start(psi);
+        process.WaitForExit(10000);
+    }
+
+    [Test]
+    public async Task RemoteToLocal_WithImpersonation_Success()
+    {
+        CreateRemoteTestFiles();
+
+        var input = new Input
+        {
+            Directory = _remoteDir,
+            Pattern = "*.txt",
+            TargetDirectory = _localTargetDir
+        };
+
+        _options.RemotePath = RemotePathType.Source;
+
+        var result = await Files.Move(input, _options, default);
+
+        ClassicAssert.AreEqual(5, result.Files.Count);
+
+        foreach (var file in result.Files)
+        {
+            ClassicAssert.IsTrue(File.Exists(file.TargetPath));
+
+            var content = await File.ReadAllTextAsync(file.TargetPath);
+            ClassicAssert.IsNotEmpty(content);
+
+            ClassicAssert.IsFalse(File.Exists(file.SourcePath));
+        }
+    }
+
+    [Test]
+    public async Task LocalToRemote_WithImpersonation_Success()
+    {
+        var input = new Input
+        {
+            Directory = _localSourceDir,
+            Pattern = "*.txt",
+            TargetDirectory = _remoteDir
+        };
+
+        _options.RemotePath = RemotePathType.Target;
+
+        var result = await Files.Move(input, _options, default);
+
+        ClassicAssert.AreEqual(5, result.Files.Count);
+
+        foreach (var file in result.Files)
+        {
+            ClassicAssert.IsTrue(File.Exists(file.TargetPath));
+            ClassicAssert.IsFalse(File.Exists(file.SourcePath));
+        }
+    }
+
+    private void CreateRemoteTestFiles()
+    {
+        // Use docker exec to create test files in the container
+        var commands = new[]
+        {
+            "echo 'Test1 content' > /mount/testshare/Test1.txt",
+            "echo 'Test2 content' > /mount/testshare/Test2.txt",
+            "echo 'Test3 content' > /mount/testshare/Test3.txt",
+            "echo 'Test4 content' > /mount/testshare/Test4.txt",
+            "echo 'Test5 content' > /mount/testshare/Test5.txt"
+        };
+
+        foreach (var command in commands)
+        {
+            var psi = new ProcessStartInfo("docker", $"exec impersonation_test_samba sh -c \"{command}\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var process = Process.Start(psi);
+            process.WaitForExit(5000);
+        }
+    }
+}

--- a/Frends.Files.Move/Frends.Files.Move.Tests/Samba/docker-compose.yml
+++ b/Frends.Files.Move/Frends.Files.Move.Tests/Samba/docker-compose.yml
@@ -1,0 +1,41 @@
+# docker-compose.yml
+version: '3.8'
+services:
+  samba:
+    image: dperson/samba:latest
+    container_name: impersonation_test_samba
+    hostname: samba-test
+    ports:
+      - "1445:445"  # Map to port 1445 to avoid conflicts
+    volumes:
+      - samba_data:/mount/testshare  # Use named volume instead of tmpfs
+    environment:
+      - USER=testuser;password123!
+      - SHARE=testshare;/mount/testshare;yes;no;no;testuser;testuser;testuser
+      - SMB=true
+      - NMBD=true
+      - WORKGROUP=WORKGROUP
+    command: >
+      sh -c "
+      /usr/bin/samba.sh -u 'testuser;password123!' -s 'testshare;/mount/testshare;yes;no;no;testuser' -p &&
+      chmod 777 /mount/testshare &&
+      chown testuser:testuser /mount/testshare &&
+      tail -f /dev/null
+      "
+    restart: unless-stopped
+    networks:
+      - test-net
+    healthcheck:
+      test: ["CMD", "smbclient", "-L", "//localhost/", "-U", "testuser%password123!", "--option=client min protocol=SMB2"]
+      interval: 15s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
+volumes:
+  samba_data:
+    driver: local
+
+networks:
+  test-net:
+    driver: bridge

--- a/Frends.Files.Move/Frends.Files.Move.Tests/UnitTests.cs
+++ b/Frends.Files.Move/Frends.Files.Move.Tests/UnitTests.cs
@@ -31,7 +31,7 @@ public class UnitTests
 
         _options = new Options
         {
-            UseGivenUserCredentialsForRemoteConnections = false,
+            RemotePath = RemotePathType.None,
             CreateTargetDirectories = false,
             IfTargetFileExists = FileExistsAction.Throw,
             PreserveDirectoryStructure = true,
@@ -59,7 +59,7 @@ public class UnitTests
     {
         var options = new Options
         {
-            UseGivenUserCredentialsForRemoteConnections = false,
+            RemotePath = RemotePathType.None,
             CreateTargetDirectories = false,
             IfTargetFileExists = FileExistsAction.Throw,
             PreserveDirectoryStructure = true
@@ -76,7 +76,7 @@ public class UnitTests
     {
         var options = new Options
         {
-            UseGivenUserCredentialsForRemoteConnections = false,
+            RemotePath = RemotePathType.None,
             CreateTargetDirectories = true,
             IfTargetFileExists = FileExistsAction.Throw,
             PreserveDirectoryStructure = true

--- a/Frends.Files.Move/Frends.Files.Move.Tests/WindowsServer/WindowsImpersonationTests.cs
+++ b/Frends.Files.Move/Frends.Files.Move.Tests/WindowsServer/WindowsImpersonationTests.cs
@@ -1,0 +1,138 @@
+﻿using Frends.Files.Move.Definitions;
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Frends.Files.Move.Tests.WindowsServer
+{
+    [TestFixture]
+    public class WindowsImpersonationTests
+    {
+        private string _localSourceDir;
+        private string _localTargetDir;
+        private string _remoteShare;
+        private Options _options;
+
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                Assert.Ignore("Windows only tests");
+
+            // Simple manual setup - just set these values for your environment
+            //_remoteShare = @"\\172.24.187.181%3a1445\testshare";
+            //_remoteShare = @"\\windows_fileserver\testshare";
+            _remoteShare = @"\\127.0.0.1\testshare";
+            _options = new Options
+            {
+                UserName = @"testfileuser",
+                Password = "Password123!",
+                CreateTargetDirectories = true,
+                IfTargetFileExists = FileExistsAction.Overwrite
+            };
+
+            // Create temp directories
+            var tempRoot = Path.Combine(Path.GetTempPath(), "ImpersonationTests");
+            _localSourceDir = Path.Combine(tempRoot, "Source");
+            _localTargetDir = Path.Combine(tempRoot, "Target");
+            Directory.CreateDirectory(_localSourceDir);
+            Directory.CreateDirectory(_localTargetDir);
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            var tempRoot = Path.GetDirectoryName(_localSourceDir);
+            if (Directory.Exists(tempRoot))
+                Directory.Delete(tempRoot, true);
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            // Create local test files
+            for (int i = 1; i <= 3; i++)
+            {
+                File.WriteAllText(Path.Combine(_localSourceDir, $"test{i}.txt"), $"Content {i}");
+            }
+
+            // Clean remote directory
+            try
+            {
+                Files.ExecuteWithImpersonation(_options, async () =>
+                {
+                    if (Directory.Exists(_remoteShare))
+                    {
+                        foreach (var file in Directory.GetFiles(_remoteShare))
+                            File.Delete(file);
+                    }
+                    await Task.CompletedTask;
+                }).Wait();
+            }
+            catch { }
+        }
+
+        [Test]
+        public async Task RemoteToLocal_MovesFiles()
+        {
+            // Arrange - Create files on remote
+            await Files.ExecuteWithImpersonation(_options, async () =>
+            {
+                for (int i = 1; i <= 3; i++)
+                {
+                    await File.WriteAllTextAsync(Path.Combine(_remoteShare, $"remote{i}.txt"), $"Remote content {i}");
+                }
+            });
+
+            var input = new Input
+            {
+                Directory = _remoteShare,
+                Pattern = "*.txt",
+                TargetDirectory = _localTargetDir
+            };
+            _options.RemotePath = RemotePathType.Source;
+
+            var result = await Files.Move(input, _options, CancellationToken.None);
+
+            Assert.That(result.Files.Count, Is.EqualTo(3));
+            foreach (var file in result.Files)
+            {
+                Assert.That(File.Exists(file.TargetPath), Is.True);
+                Assert.That(File.Exists(file.SourcePath), Is.False);
+            }
+        }
+
+        [Test]
+        public async Task LocalToRemote_MovesFiles()
+        {
+            var input = new Input
+            {
+                Directory = _localSourceDir,
+                Pattern = "*.txt",
+                TargetDirectory = _remoteShare
+            };
+            _options.RemotePath = RemotePathType.Target;
+
+            var result = await Files.Move(input, _options, CancellationToken.None);
+
+            Assert.That(result.Files.Count, Is.EqualTo(3));
+
+            await Files.ExecuteWithImpersonation(_options, async () =>
+            {
+                foreach (var file in result.Files)
+                {
+                    Assert.That(File.Exists(file.TargetPath), Is.True);
+                }
+                await Task.CompletedTask;
+            });
+
+            foreach (var file in result.Files)
+            {
+                Assert.That(File.Exists(file.SourcePath), Is.False);
+            }
+        }
+    }
+}

--- a/Frends.Files.Move/Frends.Files.Move.Tests/WindowsServer/docker-compose.yml
+++ b/Frends.Files.Move/Frends.Files.Move.Tests/WindowsServer/docker-compose.yml
@@ -1,0 +1,60 @@
+# docker-compose-windows.yml
+version: '3.8'
+services:
+  windows-fileserver:
+    image: mcr.microsoft.com/windows/servercore:ltsc2022
+    container_name: windows_fileserver
+    hostname: fileserver
+    volumes:
+      - fileserver_data:C:\SharedData
+    networks:
+      - test-net
+    command: 
+      - powershell
+      - -Command
+      - |
+        Write-Host 'Starting Windows file server setup...'
+        
+        # Create test user
+        net user testfileuser Password123 /add
+        net localgroup Administrators testfileuser /add
+        
+        # Create shared folder
+        New-Item -Path 'C:\TestShare' -ItemType Directory -Force
+        
+        # Use net share instead of New-SmbShare - this works without Server service!
+        net share testshare=C:\TestShare /GRANT:testfileuser,FULL /GRANT:Administrator,FULL
+        
+        # Set NTFS permissions
+        icacls 'C:\TestShare' /grant 'testfileuser:(OI)(CI)F' /T
+        
+        # Create test files
+        'Test content 1' | Out-File 'C:\TestShare\test1.txt' -Encoding UTF8
+        'Test content 2' | Out-File 'C:\TestShare\test2.txt' -Encoding UTF8
+        'Test content 3' | Out-File 'C:\TestShare\test3.txt' -Encoding UTF8
+        
+        Write-Host 'Setup complete - container ready'
+        
+        # Show share status
+        net share
+        
+        # Keep container running
+        while ($$true) { 
+          Start-Sleep 60
+        }
+    healthcheck:
+      test: ["CMD", "powershell", "-Command", "net share testshare"]
+      interval: 30s
+      timeout: 15s
+      retries: 5
+      start_period: 60s
+    ports:
+      - "1445:445"
+
+volumes:
+  fileserver_data:
+    driver: local
+
+networks:
+  test-net:
+    driver: nat

--- a/Frends.Files.Move/Frends.Files.Move/Definitions/Options.cs
+++ b/Frends.Files.Move/Frends.Files.Move/Definitions/Options.cs
@@ -9,20 +9,21 @@ namespace Frends.Files.Move.Definitions;
 public class Options
 {
     /// <summary>
-    /// If set, allows you to give the user credentials to use to delete files on remote hosts.
-    /// If not set, the agent service user credentials will be used.
-    /// Note: This feature is only possible with Windows agents.
+    /// Specifies which path (source or target) is remote to determine when to use 
+    /// remote credentials and Windows impersonation for file operations.
+    /// This allows the method to handle local-to-remote, remote-to-local, 
+    /// or local-to-local file copy operations appropriately.
     /// </summary>
-    /// <example>true</example>
-    [DefaultValue(false)]
-    public bool UseGivenUserCredentialsForRemoteConnections { get; set; }
+    /// <example>RemotePathType.Source</example>
+    [DefaultValue(RemotePathType.None)]
+    public RemotePathType RemotePath { get; set; }
 
     /// <summary>
     /// This needs to be of format domain\username
     /// </summary>
     /// <example>domain\username</example>
     [DefaultValue("\"domain\\username\"")]
-    [UIHint(nameof(UseGivenUserCredentialsForRemoteConnections), "", true)]
+    [UIHint(nameof(RemotePath), "", RemotePathType.Source, RemotePathType.Target)]
     public string UserName { get; set; }
 
     /// <summary>
@@ -30,7 +31,7 @@ public class Options
     /// </summary>
     /// <example>testpwd</example>
     [PasswordPropertyText]
-    [UIHint(nameof(UseGivenUserCredentialsForRemoteConnections), "", true)]
+    [UIHint(nameof(RemotePath), "", RemotePathType.Source, RemotePathType.Target)]
     public string Password { get; set; }
 
     /// <summary>

--- a/Frends.Files.Move/Frends.Files.Move/Definitions/RemotePathType.cs
+++ b/Frends.Files.Move/Frends.Files.Move/Definitions/RemotePathType.cs
@@ -1,0 +1,23 @@
+﻿namespace Frends.Files.Move.Definitions;
+
+/// <summary>
+/// Defines the types of remote path configurations for file operations.
+/// Used to identify which path requires remote credentials and impersonation.
+/// </summary>
+public enum RemotePathType
+{
+    /// <summary>
+    /// Both source and target paths are local. No remote credentials needed.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// The source path is remote. Remote credentials will be used for reading from source.
+    /// </summary>
+    Source,
+
+    /// <summary>
+    /// The target path is remote. Remote credentials will be used for writing to target.
+    /// </summary>
+    Target
+}


### PR DESCRIPTION
Implemented RemotePathType enum for credential separation in file operations. Added RemotePath property to Options class with three values: None (both local), Source (source is remote), Target (target is remote). Logic uses impersonation only for remote operations and service credentials for local operations, with memory buffer for secure transfer across credential boundaries.
Attempted Docker testing with Samba and Windows Server Core containers but hit issues.
Still need to update CHANGELOG.md and increment version.
Also commented out the old UseGivenUserCredentialsForRemoteConnections property in existing tests since it was replaced by the more specific RemotePathType enum, but haven't cleaned up all old tests yet.

[]# Frends Task Pull Request

## Summary
<!-- Brief description of changes -->

## Review Checklist

### 1. Frends Task Project Files
- Path: `Frends.*/Frends.*/*.csproj`
- [ ] Targets .NET 8
- [ ] Uses MIT license (`<PackageLicenseExpression>MIT</PackageLicenseExpression>`)
- [ ] Contains required fields:
  - [ ] `<Version>`
  - [ ] `<Authors>Frends</Authors>`
  - [ ] `<Description>`
  - [ ] `<RepositoryUrl>`
  - [ ] `<GenerateDocumentationFile>true</GenerateDocumentationFile>`

### 2. File: FrendsTaskMetadata.json
- [ ] Present: `Frends.*/Frends.*/FrendsTaskMetadata.json`
- [ ] FrendsTaskMetadata.json contains correct task method reference
- [ ] FrendsTaskMetadata.json is included in the project nuget package with path = "/"

### 3. File: README.md
- [ ] Present: `Frends.*/README.md`
- [ ] Contains badges (build, license, coverage)
- [ ] Includes developer setup instructions
- [ ] Does not include parameter descriptions

### 4. File: CHANGELOG.md
- [ ] Present: `Frends.*/CHANGELOG.md`
- [ ] Includes all functional changes
- [ ] Indicates breaking changes with upgrade notes
- [ ] Avoids non-functional notes like "refactored xyz"
- [ ] CHANGELOG.md is included in the project nuget package with path = "/"

### 5. File: migration.json
- [ ] Present: `Frends.*/Frends.*/migration.json`
- [ ] Contains breaking change migration information for Frends, if breaking changes exist
- [ ] migration.json is included in the project nuget package with path = "/"

### 6. Source Code Documentation
- Path: `Frends.*/Frends.*/*.cs`
- [ ] Every public method and class has:
  - [ ] `<summary>` XML comments
  - [ ] `<example>` XML comments
  - [ ] Optionally `<frendsdocs>` XML comments, if needed
- [ ] Follows Microsoft C# code conventions
- [ ] Uses semantic task result documentation (Success, Error, Data)

### 7. GitHub Actions Workflows
- Path: `.github/workflows/*.yml`
- [ ] Task has required workflow files:
  - [ ] `*_test.yml`
  - [ ] `*_main.yml`
  - [ ] `*_release.yml`
- [ ] Correct workdir pointing to task folder
- [ ] Docker setup included if task depends on external system (docker-compose.yml)

### 8. Task Result Object Structure
- Path: `Frends.*/Frends.*/*.cs`
- [ ] Category attribute is present, if applicable
- [ ] All task result classes include:
  - [ ] `Success` (bool)
  - [ ] Task-specific return value (e.g., Data, FilePaths), if needed
  - [ ] Error object with Message and AdditionalInfo
- [ ] Result structure is flat and simple
- [ ] Does not use 3rd-party types
- [ ] Uses dynamic JToken only when structure is unknown


---

## Additional Notes
<!-- Any additional information for reviewers -->
